### PR TITLE
Fix sent loss instead of val_loss

### DIFF
--- a/tensordash/tensordash.py
+++ b/tensordash/tensordash.py
@@ -132,7 +132,7 @@ class Customdash(object):
             acc = float("{0:.6f}".format(acc))
 
         if val_loss != None:
-            val_loss = float("{0:.6f}".format(loss))
+            val_loss = float("{0:.6f}".format(val_loss))
 
         if val_acc != None:
             val_acc = float("{0:.6f}".format(val_acc))

--- a/tensordash/torchdash.py
+++ b/tensordash/torchdash.py
@@ -45,7 +45,7 @@ class Torchdash(object):
             acc = float("{0:.6f}".format(acc))
 
         if val_loss != None:
-            val_loss = float("{0:.6f}".format(loss))
+            val_loss = float("{0:.6f}".format(val_loss))
 
         if val_acc != None:
             val_acc = float("{0:.6f}".format(val_acc))


### PR DESCRIPTION
The loss is copied into val_loss. This causes the mobile app to display two identical values for loss and val_loss.